### PR TITLE
Fix Sky card mobile layout and category tag wrapping

### DIFF
--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
         <div class="col-xl-6 d-flex">
           <div class="wrapper__project deep_blue mb-5" data-aos="fade-left" data-aos-duration="1000"
             data-aos-delay="200">
-            <div class="row h-100">
+            <div class="row">
               <div class="col-12 col-md-6 col-xl-6 mb-5 my-md-auto order-2 order-md-1 d-flex flex-column justify-content-center">
                 <h4 class="bold font__size--40 text__40-1024 text__40-mm color__white mb-1">
                   SKY
@@ -370,11 +370,9 @@
                   <div class="item medium font__size--14 text__14-1024 color__white mb-2">
                     Ideation
                   </div>
-                  <div class="w-100"></div>
                   <div class="item medium font__size--14 text__14-1024 color__white mb-2">
                     UX Design
                   </div>
-                  <div class="w-100"></div>
                   <div class="item medium font__size--14 text__14-1024 color__white mb-2">
                     UX Testing
                   </div>
@@ -383,7 +381,7 @@
                   <img src="./assets/images/Arrow 7.png" class="ml-3" alt=""  loading="lazy" />
                 </a>
               </div>
-              <div class="col-12 col-md-6 col-xl-6 px-0 d-flex align-items-center justify-content-center h-100 my-auto order-1 order-md-2">
+              <div class="col-12 col-md-6 col-xl-6 px-0 d-flex align-items-center justify-content-center my-auto order-1 order-md-2">
                 <img src="./assets/images/sky_tv.png" alt="" style="max-width: 100%; height: auto;" loading="lazy" />
               </div>
             </div>


### PR DESCRIPTION
Remove h-100 from inner row and image column to prevent overflow on mobile. Remove w-100 dividers forcing category tags onto separate rows.